### PR TITLE
Add severity score info hyperlink and HTML page

### DIFF
--- a/aura-borealis-flask-app/templates/severity_score_info.html
+++ b/aura-borealis-flask-app/templates/severity_score_info.html
@@ -1,0 +1,13 @@
+<!-- The homepage of this Flask app -->
+{% extends "layout.html" %}
+{% block content %}
+  <div class="home">
+    <h4>About the Package Severity Score</h4>
+    <p>A higher package severity score indicates relatively more and more severe indicators associated with using that package.</p>
+    <p>Methodology: A package’s severity score is the sum the severity scores associated with all the indicators linked to one package. The severity scores for each indicator are determined within <a href='https://github.com/SourceCode-AI/aura'>Aura</a>, the underlying static analysis tool on which AuraBorealis depends for data, and correspond roughly to the level of risk entailed by each indicator.</p>
+    <p>Caution: Packages with high severity scores can still be safe for usage and packages with low severity scores can be unsafe for usage. Users of AuraBorealis should not use solely these severity scores to make a decision about the safety and security of Python packages. These severity should be one input among many to a larger risk assessment process that also includes the intended application and a consultation with affected parties.</p>
+  </div>
+  <br>
+  <p>Powered by:</p>
+  <img height="100" src="./static/logotype_aura.png">
+{% endblock %}

--- a/aura-borealis-flask-app/templates/sum_warning_count.html
+++ b/aura-borealis-flask-app/templates/sum_warning_count.html
@@ -42,7 +42,7 @@
 <body>
   <div class="container" style="padding: 10px; ">
         <img src="/static/logo.png">
-        <h3 class="logo">List all packages by total indicator count and severity score</h1>
+        <h3 class="logo">List all packages by total indicator count and <a href="severity_score_info.html">severity score<a></h1>
         <a href="/">back to menu</a>
     <br/>
     <div id="toolbar"></div>

--- a/aura-borealis-flask-app/templates/sum_warning_count.html
+++ b/aura-borealis-flask-app/templates/sum_warning_count.html
@@ -42,7 +42,7 @@
 <body>
   <div class="container" style="padding: 10px; ">
         <img src="/static/logo.png">
-        <h3 class="logo">List all packages by total indicator count and <a href="severity_score_info.html">severity score<a></h1>
+        <h3 class="logo">List all packages by total indicator count and <a href="severity_score_info.html" target="_blank">severity score<a></h1>
         <a href="/">back to menu</a>
     <br/>
     <div id="toolbar"></div>


### PR DESCRIPTION
Close #16 

Add a hyperlink on sum_warning_count.html to a thorough explanation of the severity score and then add a new html template that explains the severity score methodology and caveats.

This is to make the Jeremy's of the word happy and avoid trouble with 👮 ! No lawyer emoji available, sadly.